### PR TITLE
Rebuild against libprotobuf and libabseil

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     sha256: 37017223885da29d8c42be781e8c11b84e71a3d9355b073d43b08a5dfa99229a           # [build_platform == "osx-arm64"]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -43,8 +43,8 @@ requirements:
     - libprotobuf
     - sed  # [osx]
   host:
-    - libabseil {{ libabseil }}
-    - libprotobuf {{ libprotobuf }}
+    - libabseil 20260107.0
+    - libprotobuf 6.33.5
 
 test:
   commands:


### PR DESCRIPTION
grpc_java_plugin 1.62.2

**Destination channel:** defaults

### Links

- [PKG-12557](https://anaconda.atlassian.net/browse/PKG-12557) 
- [Upstream repository](https://github.com/grpc/grpc-java/tree/v1.79.0)
### Explanation of changes:

- Rebuild against libprotobuf and libabseil


[PKG-12557]: https://anaconda.atlassian.net/browse/PKG-12557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ